### PR TITLE
Remove default for deprecated option facility

### DIFF
--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -35,7 +35,6 @@ module GELF
       self.default_options['version'] = SPEC_VERSION
       self.default_options['host'] ||= Socket.gethostname
       self.default_options['level'] ||= GELF::UNKNOWN
-      self.default_options['facility'] ||= 'gelf-rb'
       self.default_options['protocol'] ||= GELF::Protocol::UDP
 
       self.level_mapping = :logger


### PR DESCRIPTION
According to the [GELF Payload Specification](http://docs.graylog.org/en/2.4/pages/gelf.html) the field facility is "optional, deprecated" and is supposed to be sent "as additional field instead".

This default breaks field overrides, see 
* https://github.com/graylog-labs/gelf-rb/issues/57
* https://github.com/logstash-plugins/logstash-output-gelf/issues/8